### PR TITLE
Added BYTES data type conversion to convert_row_to_dict.

### DIFF
--- a/google/cloud/dataflow/io/bigquery.py
+++ b/google/cloud/dataflow/io/bigquery.py
@@ -814,6 +814,8 @@ class BigQueryWrapper(object):
         value = float(value)
       elif field.type == 'TIMESTAMP':
         value = float(value)
+      elif field.type == 'BYTES':
+        value = value
       else:
         # Note that a schema field object supports also a RECORD type. However
         # when querying, the repeated and/or record fields always come


### PR DESCRIPTION
I was trying to query table containing a BYTES column type and got `RuntimeError: Unexpected field type: BYTES`. Given that bigquery returns BYTES as a base64 string, it makes sense to interpret it the same way as a STRING. 