### PR TITLE
Adding BYTES to the possible data type options for convert_row_to_dict

### DIFF
--- a/google/cloud/dataflow/io/bigquery.py
+++ b/google/cloud/dataflow/io/bigquery.py
@@ -814,6 +814,8 @@ class BigQueryWrapper(object):
         value = float(value)
       elif field.type == 'TIMESTAMP':
         value = float(value)
+      elif field.type == 'BYTES':
+        value = value
       else:
         # Note that a schema field object supports also a RECORD type. However
         # when querying, the repeated and/or record fields always come


### PR DESCRIPTION
Since bigquery outputs a base64 string when you query a BYTES column, then it should behave the same way as with the STRING data type.